### PR TITLE
Durationpy 0.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools
     - pip
+    - wheel
   run:
     - python
 
@@ -32,9 +33,14 @@ test:
 
 about:
   home: https://github.com/icholy/durationpy
+  description: |
+    Module for converting between datetime.timedelta and Go's Duration strings.
   summary: Module for converting between datetime.timedelta and Go's Duration strings.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/icholy/durationpy
+  doc_url: https://github.com/icholy/durationpy/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,17 @@ source:
   sha256: fd3feb0a69a0057d582ef643c355c40d2fa1c942191f914d12203b1a01ac722a
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  number: 0
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - setuptools
     - pip
   run:
-    - python >={{ python_min }}
+    - python
 
 test:
   imports:
@@ -29,7 +29,6 @@ test:
     - pip check
   requires:
     - pip
-    - python {{ python_min }}
 
 about:
   home: https://github.com/icholy/durationpy


### PR DESCRIPTION
> ## ☆ Durationpy 0.9 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7636) 
[Upstream](https://github.com/icholy/durationpy)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.8
> *  Updated `about` section
